### PR TITLE
Updating readme and highs tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,3 @@ Additionally, the following syntax generates a summary that includes code covera
 ```bash
 pytest --cov-report term-missing --cov=sparow .
 ```
-
-## Getting started
-
-TODO
-
-## License
-
-TBD (probably BSD)

--- a/sparow/sp/tests/test_relax_second_stage.py
+++ b/sparow/sp/tests/test_relax_second_stage.py
@@ -5,6 +5,7 @@ from sparow.sp.util import relax_second_stage
 from sparow.ef import ExtensiveFormSolver
 
 from pyomo.opt import check_available_solvers
+
 highs_available = len(check_available_solvers("highs")) == 1
 
 

--- a/sparow/sp/tests/test_relax_second_stage.py
+++ b/sparow/sp/tests/test_relax_second_stage.py
@@ -4,6 +4,9 @@ from sparow.sp import stochastic_program
 from sparow.sp.util import relax_second_stage
 from sparow.ef import ExtensiveFormSolver
 
+from pyomo.opt import check_available_solvers
+highs_available = len(check_available_solvers("highs")) == 1
+
 
 @pytest.fixture
 def sp0():
@@ -124,6 +127,7 @@ class TestRSS(object):
                 assert M.s[b].x.domain == pyo.Binary
                 assert M.s[b].y.domain == pyo.Binary
 
+    @pytest.mark.skipif(not highs_available, reason="highs not installed")
     def test_solve_model_no_relax(self, sp3):
         sp3.initialize_bundles(scheme="single_bundle")
         b = next(iter(sp3.bundles))
@@ -140,6 +144,7 @@ class TestRSS(object):
                 assert pyo.value(M.s[b].x) == 0.0
                 assert pyo.value(M.s[b].y) == 1.0
 
+    @pytest.mark.skipif(not highs_available, reason="highs not installed")
     def test_solve_model_relax(self, sp3):
         rd = {1: True, 2: True}
         sp3.add_transformation(relax_second_stage, relax_dict=rd)


### PR DESCRIPTION
- Updating README for repo.
- relax_second_stage tests requiring highs are skipped if highs isn't installed.