### PR TITLE
Harden CI: reference head_ref via env var in the git push step

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,6 +32,8 @@ jobs:
           black .
 
       - name: Commit and push formatting changes
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           # Check if any files have been modified
           if [ -n "$(git status --porcelain)" ]; then
@@ -39,7 +41,7 @@ jobs:
             git config --global user.email "github-actions@github.com"
             git add .
             git commit -m "Auto apply black [skip ci]"
-            git push origin ${{ github.head_ref }}  # Push changes to the same PR branch
+            git push origin "$HEAD_REF"  # Push changes to the same PR branch
           else
             echo "No formatting changes detected."
           fi


### PR DESCRIPTION
While reading through the CI config I noticed the auto-format job in `.github/workflows/pytest.yml` pushes to the PR branch like this:

```yaml
git push origin ${{ github.head_ref }}
```

`github.head_ref` is the head branch name from the pull request and is set by whoever opens it. Because the `${{ }}` expression is interpolated into the script body before the shell runs, a branch name that includes shell metacharacters can break out of the intended command and execute on the runner. That is the injection risk described in GitHub's Actions hardening guidance: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections

This PR passes the value as a step environment variable and uses the quoted variable in the push:

```yaml
env:
  HEAD_REF: ${{ github.head_ref }}
run: |
  ...
  git push origin "$HEAD_REF"
```

Once the branch name comes in through `env`, the shell treats it as a plain string rather than as part of the command, closing the injection path. The step still does exactly the same thing. The `ref: ${{ github.head_ref }}` on the checkout step is a regular action input, not a shell expansion, so I left that one as is. Static analyzers (zizmor, CodeQL `actions/expression-injection`) flag the run-block form.