### PR TITLE
Change to master problem ignored variable relaxation

### DIFF
--- a/sparow/benders/benders.py
+++ b/sparow/benders/benders.py
@@ -27,7 +27,7 @@ logger = sparow.logs.logger
 
 
 class BendersSolver(object):
-    """
+    r"""
     This class provides an way to solve Stochastic Programs (or other SP formatted problems)
     using Benders Decomposition. It relies on the OR-TOPAS Benders solver for its funcitonality.
 
@@ -483,6 +483,9 @@ class BendersSolver(object):
                 # we can either fix or delete
                 # fixing for now because we do not want unneed slack variables when generating alternative solutions
                 var.domain = pyo.Reals
+                # also need to clear the upper and lower bounds
+                var.setlb(None)
+                var.setub(None)
                 var.fix(0)
 
         # step 3: create eta tracking variables for the scenario set (either 1...N or a pyomo set)


### PR DESCRIPTION
Added that master problem in Benders will treat the subproblem variables they need to 'exclude'
By fixing variable to zero after changing domain to reals and setting bounds to None,None.
It is the None, None augment that was the change.

It addresses an issue of if zero was not within the variable bounds