### PR TITLE
Sorting first stage variables

### DIFF
--- a/sparow/ph/tests/test_ph_code.py
+++ b/sparow/ph/tests/test_ph_code.py
@@ -320,7 +320,7 @@ class TestSolverAgainstMPISPPY(object):
             default_rho=10,
         )
         soln = results.last_solution
-        xbar_ph = np.array([var.value for var in reversed(soln.variables())])
+        xbar_ph = np.array([var.value for var in soln.variables()])
 
         if verbose:
             print("xbar_mpi:", xbar_mpi)
@@ -366,7 +366,7 @@ class TestSolverAgainstMPISPPY(object):
         data = []
         for scenario in scenarios:
             temp = []
-            for i in range(2, -1, -1):
+            for i in range(3):
                 temp.append(soln.variable(i).suffix.w[scenario])
             data.append(temp)
         array2 = np.array(data)

--- a/sparow/sp/sp_pyomo.py
+++ b/sparow/sp/sp_pyomo.py
@@ -129,7 +129,7 @@ class StochasticProgram_Pyomo_Base(StochasticProgram):
         b : str
             Bundle identifier.
         """
-        fsv = list(self._first_stage_variables(M=M))
+        fsv = self._first_stage_variables(M=M)
         if len(self.varcuid_to_int) == 0:
             #
             # self.varcuid_to_int maps the cuids for variables to unique integers (starting with 0).
@@ -486,7 +486,7 @@ class StochasticProgram_Pyomo_NamedBuilder(StochasticProgram_Pyomo_Base):
                 )
             )
 
-    def _first_stage_variables(self, *, M: Any) -> Any:
+    def _first_stage_variables_generator(self, *, M: Any) -> Any:
         """
         Generator function to yield first-stage variables based on their names.
 
@@ -514,6 +514,27 @@ class StochasticProgram_Pyomo_NamedBuilder(StochasticProgram_Pyomo_Base):
                     yield var.name, var
             else:
                 yield varname, comp
+
+    def _first_stage_variables(self, *, M: Any) -> Any:
+        """
+        Returns a sorted list of first-stage variables based on their names.
+
+        Parameters
+        ----------
+        M : pyomo.ConcreteModel
+            The Pyomo model to extract first-stage variables from.
+
+        Returns
+        -------
+        list
+            Tuples of (variable_name, variable_component).
+
+        Raises
+        ------
+        AssertionError
+            If a variable name is not found in the model.
+        """
+        return sorted(self._first_stage_variables_generator(M=M))
 
     def _create_scenario(self, scenario_tuple: tuple) -> Any:
         """

--- a/sparow/sp/tests/test_sp.py
+++ b/sparow/sp/tests/test_sp.py
@@ -91,15 +91,15 @@ class TestSP(object):
         M = sp2.create_subproblem("1")
 
         assert sp2.varcuid_to_int == {
-            pyo.ComponentUID("y"): 0,
-            pyo.ComponentUID("x"): 1,
+            pyo.ComponentUID("y"): 1,
+            pyo.ComponentUID("x"): 0,
         }
         assert list(sorted(sp2.int_to_FirstStageVar["1"].keys())) == [0, 1]
         assert sp2.shared_variables() == [0, 1]
-        assert sp2.get_objective_coef(0) == 0  # y
-        assert sp2.get_objective_coef(1) == 0.5  # x
-        assert sp2.get_variable_name(0) == "y"
-        assert sp2.get_variable_name(1) == "x"
+        assert sp2.get_objective_coef(0) == 0.5  # x
+        assert sp2.get_objective_coef(1) == 0  # y
+        assert sp2.get_variable_name(0) == "x"
+        assert sp2.get_variable_name(1) == "y"
 
     def test_simple3(self, sp3):
         M = sp3.create_subproblem("1")
@@ -123,7 +123,7 @@ class TestSP(object):
     def test_continuous2(self, sp2):
         M = sp2.create_subproblem("1")
         assert not sp2.continuous_fsv()
-        assert sp2._binary_or_integer_fsv == {0}
+        assert sp2._binary_or_integer_fsv == {1}
 
     def test_sp0_EF_noncompact(self, sp0):
         M = sp0.create_EF(compact_repn=False)


### PR DESCRIPTION
This ensures that all sparow model logic is
deterministic, given variable names.

This required updates to some tests that were affected by variable ordering.  But most tests were not.